### PR TITLE
2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swup/debug-plugin",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swup/debug-plugin",
-      "version": "1.0.3",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@swup/plugin": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swup/debug-plugin",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Swup Debug plugin.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Breaking change as we stopped setting the global `window.swup` instance by default.