### PR TITLE
Add more useful container checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A [swup](https://swup.js.org) plugin for debugging and helping in development.
 
-- Output all triggered hooks to the console as they happen
-- Rewrites swup's `log` method so that any output provided by plugins is visible
 - Detect common mistakes and suggest solutions in the console
+- Output all triggered hooks to the console as they happen
+- Configure swup's `log` method to make its output visible
 
 ## Installation
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,8 @@ export default class SwupDebugPlugin extends Plugin {
 		// check if title tag is present
 		this.checkDocumentTitle();
 
+		// check if all containers are present
+		this.checkContainers();
 	}
 
 	unmount() {
@@ -88,6 +90,14 @@ export default class SwupDebugPlugin extends Plugin {
 	checkDocumentTitle() {
 		if (!document.querySelector('title')) {
 			this.warn('Document is missing a title tag. It is required on every page.');
+		}
+	}
+
+	checkContainers() {
+		for (const selector of this.swup.options.containers) {
+			if (!document.querySelector(selector)) {
+				this.warn(`Container \`${selector}\` is missing on the page.`);
+			}
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Plugin from '@swup/plugin';
+import { query, queryAll } from 'swup';
 import type { Swup, HookName, HookArguments } from 'swup';
 
 declare global {
@@ -91,14 +92,14 @@ export default class SwupDebugPlugin extends Plugin {
 	}
 
 	checkDocumentTitle() {
-		if (!document.querySelector('title')) {
+		if (!query('title')) {
 			this.error('Document is missing a title tag. It is required on every page.');
 		}
 	}
 
 	checkContainers() {
 		for (const selector of this.swup.options.containers) {
-			const containers = Array.from(document.querySelectorAll(selector));
+			const containers = queryAll(selector);
 			if (!containers.length) {
 				this.error(`Container \`${selector}\` is missing on the page.`);
 			}
@@ -117,8 +118,8 @@ export default class SwupDebugPlugin extends Plugin {
 			return;
 		}
 
-		const containers = this.swup.options.containers.map((selector) => document.querySelector(selector));
-		const animatedContainers = containers.filter((container) => container?.matches(animationSelector));
+		const containers = this.swup.options.containers.map((selector) => query(selector));
+		const animatedContainers = containers.filter((el) => el?.matches(animationSelector));
 		if (!animatedContainers.length) {
 			this.warn(`No container matches the animation selector \`${animationSelector}\`.`);
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,10 +104,10 @@ export default class SwupDebugPlugin extends Plugin {
 				this.error(`Container \`${selector}\` is missing on the page.`);
 			}
 			if (containers.length > 1) {
-				this.error(`Container selector \`${selector}\` matches multiple elements.`);
+				this.error(`Container \`${selector}\` matches multiple elements.`);
 			}
-			if (containers.some((container) => !document.body.contains(container))) {
-				this.error(`Container \`${selector}\` must be a child of the body tag.`);
+			if (containers.some((container) => !container.matches('body *'))) {
+				this.error(`Container \`${selector}\` is not supported. It must be a child of the body tag.`);
 			}
 		}
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,8 +95,12 @@ export default class SwupDebugPlugin extends Plugin {
 
 	checkContainers() {
 		for (const selector of this.swup.options.containers) {
-			if (!document.querySelector(selector)) {
+			const containers = document.querySelectorAll(selector);
+			if (!containers.length) {
 				this.warn(`Container \`${selector}\` is missing on the page.`);
+			}
+			if (containers.length > 1) {
+				this.warn(`Container \`${selector}\` is present multiple times on the page.`);
 			}
 		}
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,9 @@ export default class SwupDebugPlugin extends Plugin {
 
 		// check if all containers are present
 		this.checkContainers();
+
+		// check if transition classes map to containers
+		this.checkAnimationSelector();
 	}
 
 	unmount() {
@@ -105,6 +108,19 @@ export default class SwupDebugPlugin extends Plugin {
 			if (containers.some((container) => !document.body.contains(container))) {
 				this.error(`Container \`${selector}\` must be a child of the body tag.`);
 			}
+		}
+	}
+
+	checkAnimationSelector() {
+		const { animationSelector } = this.swup.options;
+		if (!animationSelector) {
+			return;
+		}
+
+		const containers = this.swup.options.containers.map((selector) => document.querySelector(selector));
+		const animatedContainers = containers.filter((container) => container?.matches(animationSelector));
+		if (!animatedContainers.length) {
+			this.warn(`No container matches the animation selector \`${animationSelector}\`.`);
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,12 +95,15 @@ export default class SwupDebugPlugin extends Plugin {
 
 	checkContainers() {
 		for (const selector of this.swup.options.containers) {
-			const containers = document.querySelectorAll(selector);
+			const containers = Array.from(document.querySelectorAll(selector));
 			if (!containers.length) {
 				this.error(`Container \`${selector}\` is missing on the page.`);
 			}
 			if (containers.length > 1) {
 				this.error(`Container selector \`${selector}\` matches multiple elements.`);
+			}
+			if (containers.some((container) => !document.body.contains(container))) {
+				this.error(`Container \`${selector}\` must be a child of the body tag.`);
 			}
 		}
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export default class SwupDebugPlugin extends Plugin {
 
 	checkDocumentTitle() {
 		if (!document.querySelector('title')) {
-			this.warn('Document is missing a title tag. It is required on every page.');
+			this.error('Document is missing a title tag. It is required on every page.');
 		}
 	}
 
@@ -97,10 +97,10 @@ export default class SwupDebugPlugin extends Plugin {
 		for (const selector of this.swup.options.containers) {
 			const containers = document.querySelectorAll(selector);
 			if (!containers.length) {
-				this.warn(`Container \`${selector}\` is missing on the page.`);
+				this.error(`Container \`${selector}\` is missing on the page.`);
 			}
 			if (containers.length > 1) {
-				this.warn(`Container \`${selector}\` is present multiple times on the page.`);
+				this.error(`Container selector \`${selector}\` matches multiple elements.`);
 			}
 		}
 	}


### PR DESCRIPTION
**Description**

- Make debug plugin useful again 🤠 — prompted by [docs update about known issues](https://github.com/swup/docs/pull/198)
- Warn about some common mistakes early on
  - Add check if containers are present initially
  - Add check if container selector matches multiple elements
  - Add check if any of the containers matches the animation selector
- Refactor checks into instance methods
- Tested in playground

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required